### PR TITLE
Add prop to override default styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ function render() {
 | className  | string | Desired CSS className for the rendered element |
 | border     | string | Line decoration (CSS border property syntax)   | `1px solid #000`
 | zIndex     | number | Z-index offset                                 |
+| style      | object | Override default styles                        | `{ border: 'none', height: '2px', background-image: 'linear-gradient(261deg, #fd7700, #fd4400)' }`
 
 \* Required
 
@@ -77,5 +78,6 @@ function render() {
 | className  | string | Desired CSS className for the rendered element |
 | border     | string | Line decoration (CSS border property syntax)   | `1px solid #000`
 | zIndex     | number | Z-index offset                                 |
+| style      | object | Override default styles                        | `{ border: 'none', height: '2px', background-image: 'linear-gradient(261deg, #fd7700, #fd4400)' }`
 
 \* Required

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -165,8 +165,8 @@ export class Line extends PureComponent {
             width: `${length}px`,
             zIndex: this.props.zIndex || '1',
             transform: `rotate(${angle}deg)`,
-            transformOrigin: '0 0',
             // Rotate around (x0, y0)
+            transformOrigin: '0 0',
         };
 
         const defaultStyle = {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,6 +6,7 @@ const optionalStyleProps = {
     className: PropTypes.string,
     border: PropTypes.string,
     zIndex: PropTypes.number,
+    style: PropTypes.object,
 };
 
 export default class LineTo extends Component {
@@ -157,22 +158,25 @@ export class Line extends PureComponent {
         const angle = Math.atan2(dy, dx) * 180 / Math.PI;
         const length = Math.sqrt(dx * dx + dy * dy);
 
-        const style = {
+        const positionStyle = {
             position: 'absolute',
             top: `${y0}px`,
             left: `${x0}px`,
             width: `${length}px`,
-            height: '1px',
-            borderTop: this.props.border || '1px solid #f00',
             zIndex: this.props.zIndex || '1',
             transform: `rotate(${angle}deg)`,
-            // Rotate around (x0, y0)
             transformOrigin: '0 0',
+            // Rotate around (x0, y0)
+        };
+
+        const defaultStyle = {
+            height: '1px',
+            borderTop: this.props.border || '1px solid #f00',
         };
 
         const props = {
             className: this.props.className,
-            style: style,
+            style: Object.assign({}, defaultStyle, this.props.style, positionStyle),
         }
 
         // We need a wrapper element to prevent an exception when then


### PR DESCRIPTION
The option to override the default styles can be useful to get around `border`'s limitations. `border` currently doesn't have good support for gradients and images, so it'll be useful to have an option to edit the body itself instead of just the border. 

I kept the styles open, to keep the props simple, and for extra customization abilities. :)  The important styles for correct positioning override the custom styles at the end to make sure that the position remains correct.