### PR TITLE
Added the 'within' property to Line and LineTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ function render() {
 | border     | string | Line decoration (CSS border property syntax)   | `1px solid #000`
 | zIndex     | number | Z-index offset                                 |
 | style      | object | Override default styles                        | `{ border: 'none', height: '2px', background-image: 'linear-gradient(261deg, #fd7700, #fd4400)' }`
+| within     | string | CSS class name of the desired container        |
 
 \* Required
 
@@ -79,5 +80,6 @@ function render() {
 | border     | string | Line decoration (CSS border property syntax)   | `1px solid #000`
 | zIndex     | number | Z-index offset                                 |
 | style      | object | Override default styles                        | `{ border: 'none', height: '2px', background-image: 'linear-gradient(261deg, #fd7700, #fd4400)' }`
+| within     | string | CSS class name of the desired container        |
 
 \* Required

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -97,7 +97,7 @@ export default class LineTo extends Component {
     }
 
     detect() {
-        const { from, to } = this.props;
+        const { from, to, within = '' } = this.props;
 
         const a = this.findElement(from);
         const b = this.findElement(to);
@@ -112,8 +112,16 @@ export default class LineTo extends Component {
         const box0 = a.getBoundingClientRect();
         const box1 = b.getBoundingClientRect();
 
-        const offsetX = window.pageXOffset;
-        const offsetY = window.pageYOffset;
+        let offsetX = window.pageXOffset;
+        let offsetY = window.pageYOffset;
+
+        if (within) {
+            const p = this.findElement(within);
+            const boxp = p.getBoundingClientRect();
+
+            offsetX -= boxp.left;
+            offsetY -= boxp.top;
+        }
 
         const x0 = box0.left + box0.width * anchor0.x + offsetX;
         const x1 = box1.left + box1.width * anchor1.x + offsetX;
@@ -134,6 +142,7 @@ export default class LineTo extends Component {
 LineTo.propTypes = Object.assign({}, {
     from: PropTypes.string.isRequired,
     to: PropTypes.string.isRequired,
+    within: PropTypes.string,
     fromAnchor: PropTypes.string,
     toAnchor: PropTypes.string,
     delay: PropTypes.number,
@@ -141,17 +150,23 @@ LineTo.propTypes = Object.assign({}, {
 
 export class Line extends PureComponent {
     componentDidMount() {
-        // Append rendered DOM element to body so we don't have
-        // to factor in element offsets.
-        document.body.appendChild(this.el);
+        // Append rendered DOM element to the container the
+        // offsets were calculated for
+        this.within.appendChild(this.el);
     }
 
     componentWillUnmount() {
-        document.body.removeChild(this.el);
+        this.within.removeChild(this.el);
+    }
+
+    findElement(className) {
+      return document.getElementsByClassName(className)[0];
     }
 
     render() {
-        const { x0, y0, x1, y1 } = this.props;
+        const { x0, y0, x1, y1, within = '' } = this.props;
+
+        this.within = within ? this.findElement(within) : document.body;
 
         const dy = y1 - y0;
         const dx = x1 - x0;


### PR DESCRIPTION
continuation of PR #9 which was closed by GitHub automatically when reorganising the linked repo

> Adds a `within` property to both Line and LineTo, it is optional and takes a CSS class name. The resulting line is mounted within the element with that class name instead of document.body.
> 
> My use case:
> 
> I have been using react-lineto to draw connectors on graphs, in adapting the graphs for smaller displays I had to make them scrollable, for this to work in any sane manner the div being scrolled is at different offsets to `document.body`, as such it is desirable that the lines are mounted to this div and not `document.body`