### PR TITLE
Move react-dom to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "url": "https://github.com/kdeloach/react-lineto/issues"
   },
   "dependencies": {
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "16.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.22.1",
@@ -33,6 +32,7 @@
     "eslint-loader": "^1.6.1",
     "eslint-plugin-react": "^6.9.0",
     "prop-types": "15.6.0",
+    "react-dom": "16.2.0",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.3.0"
   }


### PR DESCRIPTION
Exclude `react-dom` from the published bundle since it is only needed for
the demo.

Ref #13