### PR TITLE
Fix within position

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -28,6 +28,28 @@ legend {
 #delay-test {
     height: 150px;
 }
+#tree-test .block {
+    position: relative;
+}
+.tree-test-wrap {
+    display: flex;
+    flex-Direction: row;
+    align-items: flex-start;
+    position: relative;
+}
+.tree-item {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+.tree-block-wrap {
+    padding: 0 100px 10px 0;
+}
+.tree-column {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
 .block {
     position: absolute;
     width: 50px;

--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -12,6 +12,7 @@ function Demo() {
             <SteppedTest />
             <HoverTest />
             <DelayTest />
+            <TreeTest />
         </div>
     );
 }
@@ -284,6 +285,73 @@ class DelayTest extends Component {
        );
     }
 }
+
+class TreeTest extends Component {
+    render() {
+      return (
+        <fieldset id="tree-test">
+            <legend>Tree Test</legend>
+            <div className="tree-test-wrap">
+                <TreeItem name="tree" depth={0} index={0} />
+            </div>
+        </fieldset>
+      );
+    }
+  }
+
+  class TreeItem extends Component {
+    render() {
+        const style = {
+            delay: true,
+            borderColor: '#ddd',
+            borderStyle: 'solid',
+            borderWidth: 3
+        };
+        const r = Math.ceil(((this.props.depth + 1) / 30) * 255);
+        const g = Math.ceil(((this.props.depth + 2) / 10) * 255);
+        const b = Math.ceil(((this.props.depth + 4) / 6) * 255);
+        return (
+            <div className="tree-item">
+                <div className="tree-block-wrap">
+                    <Block className={`tree-${this.props.name}`} color={`rgb(${r}, ${g}, ${b})`}>
+                        {`${String.fromCharCode(65 + this.props.depth)}${this.props.index}`}
+                    </Block>
+                </div>
+                {this.props.depth < 5 ? (
+                    <div className="tree-column">
+                        {Array(Math.ceil(Math.random() * 3) + 1).fill(null).
+                            map((_, i) => (
+                                <TreeItem
+                                    parent={this}
+                                    index={this.props.index * this.props.depth + i}
+                                    name={`${this.props.name}-child-${i}`}
+                                    depth={this.props.depth + 1}
+                                />
+                            ))
+                        }
+                    </div>
+                ) : null}
+                {this.props.parent ? (
+                    <SteppedLineTo
+                        within="tree-test-wrap"
+                        from={`tree-${this.props.parent.props.name}`}
+                        to={`tree-${this.props.name}`}
+                        fromAnchor="right"
+                        toAnchor="left"
+                        orientation="h"
+                        {...style} />
+                ) : null}
+            </div>
+      );
+    }
+  }
+
+  TreeItem.propTypes = {
+    depth: PropTypes.number,
+    index: PropTypes.number,
+    parent: PropTypes.instanceOf(TreeItem),
+    name: PropTypes.string
+  };
 
 function createRootElement() {
     const root = document.createElement('div');

--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -292,7 +292,7 @@ class TreeTest extends Component {
         <fieldset id="tree-test">
             <legend>Tree Test</legend>
             <div className="tree-test-wrap">
-                <TreeItem name="tree" depth={0} index={0} />
+                <TreeItem name="" depth={0} index={0} />
             </div>
         </fieldset>
       );
@@ -307,24 +307,23 @@ class TreeTest extends Component {
             borderStyle: 'solid',
             borderWidth: 3
         };
-        const r = Math.ceil(((this.props.depth + 1) / 30) * 255);
-        const g = Math.ceil(((this.props.depth + 2) / 10) * 255);
-        const b = Math.ceil(((this.props.depth + 4) / 6) * 255);
+        const h = ({ _: 20, A: 120, B: 100, C: 200, D: 50 })[this.props.name[0] || '_'];
+        const l = Math.ceil(((this.props.index + 2) / 20) * 100) + 10 * (this.props.depth + 1);
         return (
             <div className="tree-item">
                 <div className="tree-block-wrap">
-                    <Block className={`tree-${this.props.name}`} color={`rgb(${r}, ${g}, ${b})`}>
-                        {`${String.fromCharCode(65 + this.props.depth)}${this.props.index}`}
+                    <Block className={`tree-${this.props.name}`} color={`hsl(${h}, 100%, ${l}%)`}>
+                        {this.props.name || 'X'}
                     </Block>
                 </div>
-                {this.props.depth < 5 ? (
+                {this.props.depth < 2 ? (
                     <div className="tree-column">
                         {Array(Math.ceil(Math.random() * 3) + 1).fill(null).
                             map((_, i) => (
                                 <TreeItem
                                     parent={this}
                                     index={this.props.index * this.props.depth + i}
-                                    name={`${this.props.name}-child-${i}`}
+                                    name={`${this.props.name}${String.fromCharCode(65 + i)}`}
                                     depth={this.props.depth + 1}
                                 />
                             ))

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -148,8 +148,8 @@ export default class LineTo extends Component {
             const p = this.findElement(within);
             const boxp = p.getBoundingClientRect();
 
-            offsetX -= boxp.left;
-            offsetY -= boxp.top;
+            offsetX -= boxp.left + window.scrollX;
+            offsetY -= boxp.top + window.scrollY;
         }
 
         const x0 = box0.left + box0.width * anchor0.x + offsetX;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -148,8 +148,8 @@ export default class LineTo extends Component {
             const p = this.findElement(within);
             const boxp = p.getBoundingClientRect();
 
-            offsetX -= boxp.left + window.scrollX;
-            offsetY -= boxp.top + window.scrollY;
+            offsetX -= boxp.left + (window.pageXOffset || document.documentElement.scrollLeft);
+            offsetY -= boxp.top + (window.pageYOffset || document.documentElement.scrollTop);
         }
 
         const x0 = box0.left + box0.width * anchor0.x + offsetX;


### PR DESCRIPTION
Hello,

I've experienced displaying misaligned lines when using `within` attribute like `TreeTest` demo contained in this PR.

I added scroll position to calculation.

Thanks,